### PR TITLE
NISP-2274: Modify Audit Events

### DIFF
--- a/app/uk/gov/hmrc/nationalinsurancerecord/controllers/NationalInsuranceRecordController.scala
+++ b/app/uk/gov/hmrc/nationalinsurancerecord/controllers/NationalInsuranceRecordController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.api.controllers.HeaderValidator
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.nationalinsurancerecord.connectors.CustomAuditConnector
 import uk.gov.hmrc.nationalinsurancerecord.domain.{Exclusion, TaxYear, TaxYearSummary}
-import uk.gov.hmrc.nationalinsurancerecord.events.{NationalInsuranceRecord, NationalInsuranceRecordExclusion}
+import uk.gov.hmrc.nationalinsurancerecord.events.{NationalInsuranceExclusion, NationalInsuranceRecord}
 import uk.gov.hmrc.nationalinsurancerecord.services.NationalInsuranceRecordService
 import uk.gov.hmrc.play.microservice.controller.BaseController
 import uk.gov.hmrc.nationalinsurancerecord.domain.NationalInsuranceTaxYear
@@ -42,36 +42,36 @@ trait NationalInsuranceRecordController extends BaseController with HeaderValida
     )
   }
 
-	def getSummary(nino: Nino): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async {
+  def getSummary(nino: Nino): Action[AnyContent] = validateAccept(acceptHeaderValidationRules).async {
     implicit request =>
       errorWrapper(nationalInsuranceRecordService.getNationalInsuranceRecord(nino).map {
 
         case Left(exclusion) => {
           if (exclusion.exclusionReasons.contains(Exclusion.Dead)) {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, List(Exclusion.Dead)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, List(Exclusion.Dead)))
             Forbidden(Json.toJson(ErrorResponses.ExclusionDead))
           } else if (exclusion.exclusionReasons.contains(Exclusion.ManualCorrespondenceIndicator)) {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, List(Exclusion.ManualCorrespondenceIndicator)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, List(Exclusion.ManualCorrespondenceIndicator)))
             Forbidden(Json.toJson(ErrorResponses.ExclusionManualCorrespondence))
           } else if (exclusion.exclusionReasons.contains(Exclusion.MarriedWomenReducedRateElection)) {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, List(Exclusion.MarriedWomenReducedRateElection)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, List(Exclusion.MarriedWomenReducedRateElection)))
             Forbidden(Json.toJson(ErrorResponses.ExclusionMarriedWomenReducedRate))
           } else if (exclusion.exclusionReasons.contains(Exclusion.IsleOfMan)) {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, List(Exclusion.IsleOfMan)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, List(Exclusion.IsleOfMan)))
             Forbidden(Json.toJson(ErrorResponses.ExclusionIsleOfMan))
           } else {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, exclusion.exclusionReasons))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, exclusion.exclusionReasons))
             Ok(halResourceSelfLink(Json.toJson(exclusion), nationalInsuranceRecordHref(nino)))
           }
         }
 
         case Right(nationalInsuranceRecord) =>
           customAuditConnector.sendEvent(NationalInsuranceRecord(nino, nationalInsuranceRecord.qualifyingYears,
-                nationalInsuranceRecord.qualifyingYearsPriorTo1975, nationalInsuranceRecord.numberOfGaps,
-                nationalInsuranceRecord.numberOfGapsPayable, nationalInsuranceRecord.dateOfEntry,
-                nationalInsuranceRecord.homeResponsibilitiesProtection
-              )
-          )
+            nationalInsuranceRecord.qualifyingYearsPriorTo1975, nationalInsuranceRecord.numberOfGaps,
+            nationalInsuranceRecord.numberOfGapsPayable, nationalInsuranceRecord.dateOfEntry,
+            nationalInsuranceRecord.homeResponsibilitiesProtection, nationalInsuranceRecord.earningsIncludedUpTo,
+            nationalInsuranceRecord.taxYears.length
+          ))
 
           Ok(halResourceWithTaxYears(nino, Json.toJson(nationalInsuranceRecord), nationalInsuranceRecordHref(nino),
             years = nationalInsuranceRecord.taxYears))
@@ -84,32 +84,32 @@ trait NationalInsuranceRecordController extends BaseController with HeaderValida
 
         case Left(exclusion) =>
           if (exclusion.exclusionReasons.contains(Exclusion.Dead)) {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, List(Exclusion.Dead)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, List(Exclusion.Dead)))
             Forbidden(Json.toJson(ErrorResponses.ExclusionDead))
           } else if (exclusion.exclusionReasons.contains(Exclusion.ManualCorrespondenceIndicator)) {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, List(Exclusion.ManualCorrespondenceIndicator)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, List(Exclusion.ManualCorrespondenceIndicator)))
             Forbidden(Json.toJson(ErrorResponses.ExclusionManualCorrespondence))
           } else if (exclusion.exclusionReasons.contains(Exclusion.MarriedWomenReducedRateElection)) {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, List(Exclusion.MarriedWomenReducedRateElection)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, List(Exclusion.MarriedWomenReducedRateElection)))
             Forbidden(Json.toJson(ErrorResponses.ExclusionMarriedWomenReducedRate))
           } else if (exclusion.exclusionReasons.contains(Exclusion.IsleOfMan)) {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, List(Exclusion.IsleOfMan)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, List(Exclusion.IsleOfMan)))
             Forbidden(Json.toJson(ErrorResponses.ExclusionIsleOfMan))
           } else {
-            customAuditConnector.sendEvent(NationalInsuranceRecordExclusion(nino, exclusion.exclusionReasons))
-            Ok(halResourceSelfLink(Json.toJson(exclusion), nationalInsuranceTaxYearHref(nino,taxYear)))
+            customAuditConnector.sendEvent(NationalInsuranceExclusion(nino, exclusion.exclusionReasons))
+            Ok(halResourceSelfLink(Json.toJson(exclusion), nationalInsuranceTaxYearHref(nino, taxYear)))
           }
 
         case Right(nationalInsuranceTaxYear) =>
           import uk.gov.hmrc.nationalinsurancerecord.events.NationalInsuranceTaxYear
           customAuditConnector.sendEvent(NationalInsuranceTaxYear(nino, nationalInsuranceTaxYear.taxYear,
-              nationalInsuranceTaxYear.qualifying, nationalInsuranceTaxYear.classOneContributions,
-              nationalInsuranceTaxYear.classTwoCredits, nationalInsuranceTaxYear.classThreeCredits,
-              nationalInsuranceTaxYear.otherCredits, nationalInsuranceTaxYear.classThreePayable,
-              nationalInsuranceTaxYear.classThreePayableBy, nationalInsuranceTaxYear.classThreePayableByPenalty,
-              nationalInsuranceTaxYear.payable, nationalInsuranceTaxYear.underInvestigation))
+            nationalInsuranceTaxYear.qualifying, nationalInsuranceTaxYear.classOneContributions,
+            nationalInsuranceTaxYear.classTwoCredits, nationalInsuranceTaxYear.classThreeCredits,
+            nationalInsuranceTaxYear.otherCredits, nationalInsuranceTaxYear.classThreePayable,
+            nationalInsuranceTaxYear.classThreePayableBy, nationalInsuranceTaxYear.classThreePayableByPenalty,
+            nationalInsuranceTaxYear.payable, nationalInsuranceTaxYear.underInvestigation))
 
-          Ok(halResourceSelfLink(Json.toJson(nationalInsuranceTaxYear), nationalInsuranceTaxYearHref(nino,taxYear)))
+          Ok(halResourceSelfLink(Json.toJson(nationalInsuranceTaxYear), nationalInsuranceTaxYearHref(nino, taxYear)))
       })
 
   }

--- a/app/uk/gov/hmrc/nationalinsurancerecord/events/NationalInsuranceExclusion.scala
+++ b/app/uk/gov/hmrc/nationalinsurancerecord/events/NationalInsuranceExclusion.scala
@@ -20,13 +20,13 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.nationalinsurancerecord.domain.Exclusion
 import uk.gov.hmrc.play.http.HeaderCarrier
 
-object NationalInsuranceRecordExclusion{
-  def apply(nino: Nino, exclusionReasons: List[Exclusion.Exclusion])(implicit hc: HeaderCarrier): NationalInsuranceRecordExclusion =
-    new NationalInsuranceRecordExclusion(nino, exclusionReasons)
+object NationalInsuranceExclusion{
+  def apply(nino: Nino, exclusionReasons: List[Exclusion.Exclusion])(implicit hc: HeaderCarrier): NationalInsuranceExclusion =
+    new NationalInsuranceExclusion(nino, exclusionReasons)
 }
 
-class NationalInsuranceRecordExclusion(nino: Nino, exclusionReasons: List[Exclusion.Exclusion]) (implicit hc: HeaderCarrier)
-  extends BusinessEvent("NationalInsuranceRecordExclusion", nino,
+class NationalInsuranceExclusion(nino: Nino, exclusionReasons: List[Exclusion.Exclusion]) (implicit hc: HeaderCarrier)
+  extends BusinessEvent("NationalInsuranceExclusion", nino,
     Map(
       "reasons" -> exclusionReasons.map(_.toString).mkString(",")
     )

--- a/app/uk/gov/hmrc/nationalinsurancerecord/events/NationalInsuranceRecord.scala
+++ b/app/uk/gov/hmrc/nationalinsurancerecord/events/NationalInsuranceRecord.scala
@@ -20,30 +20,34 @@ import org.joda.time.LocalDate
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.http.HeaderCarrier
 
-object NationalInsuranceRecord{
+object NationalInsuranceRecord {
   def apply(nino: Nino, qualifyingYears: Int, qualifyingYearsPriorTo1975: Int,
             numberOfGaps: Int, numberOfGapsPayable: Int, dateOfEntry: LocalDate,
-            homeResponsibilitiesProtection: Boolean)(implicit hc: HeaderCarrier): NationalInsuranceRecord =
+            homeResponsibilitiesProtection: Boolean, earningsIncludedUpTo: LocalDate, numberOfTaxYears: Int)(implicit hc: HeaderCarrier): NationalInsuranceRecord =
     new NationalInsuranceRecord(nino: Nino, qualifyingYears: Int,
-                                           qualifyingYearsPriorTo1975: Int,
-                                           numberOfGaps: Int,
-                                           numberOfGapsPayable: Int,
-                                           dateOfEntry: LocalDate,
-                                           homeResponsibilitiesProtection: Boolean
-                                          )
+      qualifyingYearsPriorTo1975: Int,
+      numberOfGaps: Int,
+      numberOfGapsPayable: Int,
+      dateOfEntry: LocalDate,
+      homeResponsibilitiesProtection: Boolean,
+      earningsIncludedUpTo: LocalDate,
+      numberOfTaxYears: Int
+    )
 }
 
 class NationalInsuranceRecord(nino: Nino, qualifyingYears: Int, qualifyingYearsPriorTo1975: Int,
                               numberOfGaps: Int, numberOfGapsPayable: Int, dateOfEntry: LocalDate,
-                              homeResponsibilitiesProtection: Boolean) (implicit hc: HeaderCarrier)
-  extends BusinessEvent("NationalInsuranceRecordSummary", nino,
+                              homeResponsibilitiesProtection: Boolean, earningsIncludedUpTo: LocalDate, numberOfTaxYears: Int)(implicit hc: HeaderCarrier)
+  extends BusinessEvent("NationalInsuranceRecord", nino,
     Map(
       "qualifyingYears" -> qualifyingYears.toString,
       "qualifyingYearsPriorTo1975" -> qualifyingYearsPriorTo1975.toString,
       "numberOfGaps" -> numberOfGaps.toString,
       "numberOfGapsPayable" -> numberOfGapsPayable.toString,
       "dateOfEntry" -> dateOfEntry.toString,
-      "homeResponsibilitiesProtection" -> homeResponsibilitiesProtection.toString
+      "homeResponsibilitiesProtection" -> homeResponsibilitiesProtection.toString,
+      "earningsIncludedUpTo" -> earningsIncludedUpTo.toString,
+      "numberOfTaxYears" -> numberOfTaxYears.toString
     )
 
   )

--- a/app/uk/gov/hmrc/nationalinsurancerecord/events/NationalInsuranceTaxYear.scala
+++ b/app/uk/gov/hmrc/nationalinsurancerecord/events/NationalInsuranceTaxYear.scala
@@ -57,7 +57,7 @@ class NationalInsuranceTaxYear(nino: Nino, taxYear: String,
                                classThreePayableByPenalty: Option[LocalDate],
                                payable: Boolean,
                                underInvestigation: Boolean) (implicit hc: HeaderCarrier)
-  extends BusinessEvent("NationalInsuranceRecordTaxYear", nino,
+  extends BusinessEvent("NationalInsuranceTaxYear", nino,
     Map(
       "taxYear" -> taxYear.toString,
       "qualifying" -> qualifying.toString,
@@ -66,8 +66,8 @@ class NationalInsuranceTaxYear(nino: Nino, taxYear: String,
       "classThreeCredits" -> classThreeCredits.toString,
       "otherCredits" -> otherCredits.toString,
       "classThreePayable" -> classThreePayable.toString,
-      "classThreePayableBy" -> classThreePayableBy.toString,
-      "classThreePayableByPenalty" -> classThreePayableByPenalty.toString,
+      "classThreePayableBy" -> classThreePayableBy.map(_.toString).getOrElse(""),
+      "classThreePayableByPenalty" -> classThreePayableByPenalty.map(_.toString).getOrElse(""),
       "payable" -> payable.toString,
       "underInvestigation" -> underInvestigation.toString
     )


### PR DESCRIPTION
This PR modifies the names of the audit events to be a bit simpler.
I've also added a new couple of fields from the objects that were missing from the events.
I've also made sure `Option`s get converted to strings correctly.