### PR TITLE
Revert "DDCNLS-6523: Change auth predicate to always check for NINO"

### DIFF
--- a/app/uk/gov/hmrc/nationalinsurancerecord/controllers/auth/AuthAction.scala
+++ b/app/uk/gov/hmrc/nationalinsurancerecord/controllers/auth/AuthAction.scala
@@ -46,7 +46,7 @@ class AuthActionImpl @Inject()(val authConnector: AuthConnector)(implicit execut
       Future.successful(Some(BadRequest))
     } else {
       val uriNino: Option[String] = Some(matches.group(1))
-      authorised(ConfidenceLevel.L200 and Nino(hasNino = true, uriNino)) {
+      authorised((AuthProviders(PrivilegedApplication)) or (ConfidenceLevel.L200 and Nino(hasNino = true, uriNino))) {
         Future.successful(None)
       }.recover {
         case t: Throwable =>

--- a/test/uk/gov/hmrc/nationalinsurancerecord/controllers/auth/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/nationalinsurancerecord/controllers/auth/AuthActionSpec.scala
@@ -63,7 +63,7 @@ class AuthActionSpec
     }
 
     "the user is logged in" must {
-      "return the request when the user is authorised and the nino in the uri matches" in {
+      "return the request when the user is authorised and the nino in the uri matches or user is coming from a privileged application" in {
 
         val (result, mockAuthConnector) =
           testAuthActionWith(Future.successful(()))
@@ -71,7 +71,7 @@ class AuthActionSpec
         status(result) mustBe OK
 
         verify(mockAuthConnector)
-          .authorise[Unit](MockitoEq(ConfidenceLevel.L200 and Nino(true, Some(testNino))),
+          .authorise[Unit](MockitoEq((AuthProviders(PrivilegedApplication)) or (ConfidenceLevel.L200 and Nino(true, Some(testNino)))),
             any())(any(), any())
       }
 


### PR DESCRIPTION
Reverts hmrc/national-insurance-record#61